### PR TITLE
Fixing List height on map.css

### DIFF
--- a/represent-map/map.css
+++ b/represent-map/map.css
@@ -215,11 +215,10 @@ html, body, #map_canvas
   z-index: 3;
   right: 0;
   top: 0;
-  height: 100px;
+  height: 100%;
   border-left: 1px solid #ccc;
   border-top: 1px solid #ccc;
   overflow-y: scroll;
-  height: 100px;
   background-color: #333;
 }
 .typeahead.dropdown-menu


### PR DESCRIPTION
There was a duplication height reference with fixed height of 100px instead of only one line with 100% height.
