### PR TITLE
add markerclusterer

### DIFF
--- a/represent-map/index.php
+++ b/represent-map/index.php
@@ -27,6 +27,7 @@ include_once "header.php";
     <script src="./bootstrap/js/bootstrap-typeahead.js" type="text/javascript" charset="utf-8"></script>
     <script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?sensor=false"></script>
     <script type="text/javascript" src="./scripts/label.js"></script>
+    <script type="text/javascript" src="http://google-maps-utility-library-v3.googlecode.com/svn/tags/markerclusterer/1.0.2/src/markerclusterer.js"></script>
     
     <script type="text/javascript">
       var map;
@@ -292,6 +293,38 @@ include_once "header.php";
           label.bindTo('clickable', marker);
           label.bindTo('zIndex', marker);
         });
+		var mcOptions = {gridSize: 10, maxZoom: 19};
+        var markerCluster = new MarkerClusterer(map, gmarkers, mcOptions);
+        var infowindowlist = new google.maps.InfoWindow({
+          content: ""
+        });
+      google.maps.event.addListener(markerCluster, "clusterclick", function(c) {
+      var currentZoom = map.getZoom();
+      infowindowlist.close();
+      if(currentZoom >= 17) {
+        var myLatlng = new google.maps.LatLng(c.getCenter().lat(), c.getCenter().lng());
+        var n = "";
+        var markerId = new Array();
+      
+        infowindowlist.close();
+        
+        n += '<div class="clusterList"><ul>';
+
+        for (var i = 0; i < c.markerClusterer_.clusters_[0].markers_.length; i++) {
+          markerId = (c.markerClusterer_.clusters_[0].markers_[i].list);
+          n += '<li class="clusterListItem"><a href="#" onclick="goToMarker(\'' + markerId + '\')">' + markerTitle[markerId] +'</a></li>'
+        }
+        n += '</ul></div>';
+
+        infowindowlist.setContent(n);
+        infowindowlist.setPosition(myLatlng);
+        infowindowlist.open(map);
+      }
+    });
+      
+      MarkerClusterer.prototype.onClick = function() { 
+      return true; 
+    };
 
 
         // zoom to marker if selected in search typeahead list


### PR DESCRIPTION
add MarkerClusterer for Google Maps v3, the library creates and manages per-zoom-level clusters for large amounts of markers. 
