### PR TITLE
Adding config/setup script for using Vagrant virtual machines for development.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# so you don't accidentally commit your production credentials
+represent-map/include/db.php
+
+.vagrant

--- a/README.md
+++ b/README.md
@@ -89,6 +89,21 @@ on your map unless you've been given explicit, written permission from any of th
 remove it.
 
 
+Contributing / Development
+--------------------------
+
+For development purposes, a [Vagrant](http://www.vagrantup.com/) virtual machine
+configuration has been added. Once Vagrant and VirtualBox (or your Vagrant
+provider of choice) have been installed, you can get an instance of RepresentMap
+up and running quickly with
+
+    vagrant up
+
+This will download and start the virtual machine, install all of the required
+software to run RepresentMap, and configure MySQL and Apache. You will then be
+able to access the map via http://localhost:8080
+
+
 Useful Links
 ------------
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,11 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "precise32"
+  config.vm.box_url = "http://files.vagrantup.com/precise32.box"
+  config.vm.network :forwarded_port, guest: 80, host: 8080
+
+  config.vm.provision :shell,
+    inline: "sudo /vagrant/setup_vm.sh"
+end

--- a/setup_vm.sh
+++ b/setup_vm.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# Stop completely on any error
+set -e
+
+# Check to see if this script has already been run
+# Only needs to be done the first time the machine is brought up
+if [[ -e /home/vagrant/.installed ]]; then exit; fi
+
+# Install Packages
+PACKAGES="apache2 mysql-server php5 php5-mysql"
+apt-get update
+# Allows MySQL to be installed w/o glyph problems from root password prompt
+DEBIAN_FRONTEND=noninteractive aptitude install -q -y $PACKAGES
+
+# Setup Represent Map
+cat /vagrant/represent-map/include/db_example.php | \
+sed s/"\[db_host\]"/localhost/ | \
+sed s/"\[db_name\]"/representmap/ | \
+sed s/"\[db_user\]"/root/ | \
+sed s/"\[db_pass\]"/password/ | \
+sed s/"\[admin_user\]"/admin/ | \
+sed s/"\[admin_pass\]"/admin/ > /vagrant/represent-map/include/db.php
+
+# Setup MySQL
+mysql -uroot -e \
+"UPDATE mysql.user SET password=PASSWORD('password') WHERE user='root'; \
+CREATE DATABASE representmap; \
+FLUSH PRIVILEGES;"
+
+mysql -uroot -ppassword representmap < /vagrant/represent-map/db/events_1.sql
+mysql -uroot -ppassword representmap < /vagrant/represent-map/db/places_3.sql
+mysql -uroot -ppassword representmap < /vagrant/represent-map/db/settings_1.sql
+
+# Setup Apache
+cat > /etc/apache2/sites-enabled/000-default <<EOS
+<VirtualHost *:80>
+    DocumentRoot /vagrant/represent-map
+
+  <Directory /vagrant/represent-map/>
+    Options FollowSymLinks
+    AllowOverride All
+    Order allow,deny
+    Allow from all
+  </Directory>
+
+  <Directory ~ "\.git">
+    Order allow,deny
+    Deny from all
+  </Directory>
+</VirtualHost>
+EOS
+
+/etc/init.d/apache2 restart
+
+# Set lock file so this script won't run next time
+touch /home/vagrant/.installed
+
+cat <<EOS
+Represent Map should now be running on http://localhost:8080
+---
+The credentials are as follows:
+db_host: localhost
+db_name: representmap
+db_user: root
+db_pass: password
+admin_user: admin
+admin_pass: admin
+
+This is intended to be for testing/development purposes.
+You should ABSOLUTELY NOT use this script for a production install without
+changing the config in represent-map/include/db.php first!
+EOS


### PR DESCRIPTION
Instructions on how to use RepresentMap with Vagrant were added to the README.
