### PR TITLE
Custom Map Subsections with URL Routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ entire state of Michigan. By default, the map is so large, the individual
 location pins overlap. To quickly see just
 [Detroit](https://representmi.com/detroit), RepresentMap can support extra
 custom URLs by configuring them with ``url_routes.php``. For more details, see
-url_routes.md
+[url_routes.md](https://github.com/charlesthomas/represent-map/blob/url_routing/url_routes.md)
 
 
 License

--- a/README.md
+++ b/README.md
@@ -77,6 +77,18 @@ You can automatically show local events in your community on your map! Just foll
    chron on your server. If you don't know how to do that, ask your hosting provider.
 
 
+Map Subsections (optional)
+--------------------------
+
+For large maps, it may be useful to have subsections of the map exposed through
+custom URLs. For example, [RepresentMI](https://representmi.com) covers the
+entire state of Michigan. By default, the map is so large, the individual
+location pins overlap. To quickly see just
+[Detroit](https://representmi.com/detroit), RepresentMap can support extra
+custom URLs by configuring them with ``url_routes.php``. For more details, see
+url_routes.md
+
+
 License
 -------
 

--- a/represent-map/include/url_routes_example.php
+++ b/represent-map/include/url_routes_example.php
@@ -1,0 +1,9 @@
+<?php
+$url_routes = array(
+    // extra urls can be added here to have custom latitude, longitude, and zoom
+    // levels
+    // zoom_level is not required; the default will be used if not supplied
+    // see url_routes.md for extra info
+    'custom_url' =>  'latitude,longitude,zoom_level',
+);
+?>

--- a/represent-map/index.php
+++ b/represent-map/index.php
@@ -1,6 +1,30 @@
 <?php
 if(!file_exists('include/db.php')) require_once('installer.php');
 include_once "header.php";
+
+if(file_exists('include/url_routes.php')) {
+    include_once 'include/url_routes.php';
+    require_once 'Breeze.php';
+
+    get(';/(.*)$;', function($app, $params) {
+        global $url_routes;
+        global $lat_lng;
+        global $zoom_level;
+
+        //cleanup param
+        $params[1] = str_replace(array('%20', ' ', '-', '_'), '', $params[1]);
+
+        if(array_key_exists($params[1], $url_routes)) {
+            $data = split(',', $url_routes[$params[1]]);
+            $lat_lng = $data[0] . "," . $data[1];
+            if(count($data) > 2) {
+                $zoom_level = $data[2];
+            }
+        }
+    });
+
+    run();
+}
 ?>
 
 <!DOCTYPE html>
@@ -131,7 +155,7 @@ include_once "header.php";
 
         // set map options
         var myOptions = {
-          zoom: 11,
+          zoom: <?= (isset($zoom_level) ? $zoom_level : 11) ?>,
           //minZoom: 10,
           center: new google.maps.LatLng(<?= $lat_lng ?>),
           mapTypeId: google.maps.MapTypeId.ROADMAP,

--- a/url_routes.md
+++ b/url_routes.md
@@ -14,7 +14,7 @@ Setup
 -----
 
 1. Your webserver will need [URL Rewriting
-   configured](https://github.com/whatthejeff/breeze/blob/master/INSTALL.md)
+   configured](https://github.com/whatthejeff/breeze/blob/master/INSTALL.md#server-configurations)
 1. In ``represent-map/include``, rename ``url_routes_example.php`` to
    ``url_routes.php``
 1. Add custom URLs to ``url_routes.php``

--- a/url_routes.md
+++ b/url_routes.md
@@ -1,0 +1,52 @@
+Custom URL Routes
+=================
+
+Requirements
+------------
+
+This feature requires more strict requirements than the rest of RepresentMap.
+
+- PHP 5.3 or higher
+- [PHP Breeze](https://github.com/whatthejeff/breeze)
+
+
+Setup
+-----
+
+1. Your webserver will need [URL Rewriting
+   configured](https://github.com/whatthejeff/breeze/blob/master/INSTALL.md)
+1. In ``represent-map/include``, rename ``url_routes_example.php`` to
+   ``url_routes.php``
+1. Add custom URLs to ``url_routes.php``
+
+
+Syntax
+------
+
+Here is a sample ``url_routes.php`` file:
+
+    <?php
+    $url_routes = array(
+        'url' => 'latitude,longitude,zoom_level',
+        'url2' => 'latitude,longitude'
+    );
+    ?>
+
+Above, 'url' and 'url2' are the URLs that will be available
+(representmap.com/url and representmap.com/url2). RepresentMap will
+automatically remove spaces, underscores, dashes, and %20s in the url in order
+to figure out which url_route to use. (representmap.com/url2,
+representmap.com/url-2, and representmap.com/url_2 are all identical, and will
+use 'url2' above. 'Latitude' and 'longitude' should be self-explanatory.
+'Zoom_level' is optional, but recommended. Out of the box, the zoom level on
+RepresentMap is 11. Setting a custom URL with a different latitude and longitude
+but no custom zoom level would result in the map just being shifted. Adding the
+zoom level will also show a smaller (or larger) portion of the map.
+
+
+Warning
+-------
+
+Trailing slashes on the custom URL result in strange behavior. Not sure if this
+is because of the web server, Breeze, or RepresentMap itself. Use
+representmap.com/url, **not** representmap.com/url/.


### PR DESCRIPTION
This will allow subsections of the map to be exposed under extra URLs. To see examples, compare [RepresentMI](https://representmi.com) to [Detroit](https://representmi.com/detroit) or [Ann Arbor](https://representmi.com/annarbor)
